### PR TITLE
Implement projects pages with slugs

### DIFF
--- a/app/components/Navbar.jsx
+++ b/app/components/Navbar.jsx
@@ -1,5 +1,6 @@
 'use client';
 import React, { useEffect, useState, useRef } from 'react';
+import Link from 'next/link';
 
 
 
@@ -100,8 +101,15 @@ const Navbar = ({ isDarkMode, setIsDarkMode }) => {
                   {item.name}
                 </a>
               ))}
+              <Link
+                href="/projects"
+                className="px-3 py-2 rounded-md text-sm font-medium transition-colors duration-200 hover:bg-theme-hover"
+                style={{ color: 'var(--text-color)' }}
+              >
+                Projects
+              </Link>
+              </div>
             </div>
-          </div>
 
           {/* Theme Toggle & Mobile Menu Button */}
           <div className="flex items-center space-x-4">
@@ -163,6 +171,14 @@ const Navbar = ({ isDarkMode, setIsDarkMode }) => {
                   {item.name}
                 </a>
               ))}
+              <Link
+                href="/projects"
+                className="block px-3 py-2 rounded-md text-base font-medium transition-colors duration-200 hover:bg-theme-hover"
+                style={{ color: 'var(--text-color)' }}
+                onClick={() => setIsMobileMenuOpen(false)}
+              >
+                Projects
+              </Link>
             </div>
           </div>
         )}

--- a/app/components/Work.jsx
+++ b/app/components/Work.jsx
@@ -1,4 +1,5 @@
 import Image from 'next/image'
+import Link from 'next/link'
 import { assets, workData } from '../../assets/assets'
 import React from 'react'
 import DynamicArrow from './DynamicArrow';
@@ -16,42 +17,36 @@ const Work = (isDarkMode) => {
 
 
     <div className='grid grid-cols-auto my-10 gap-5'>
-        {workData.map((project, index)=>(
-            <div key={index} 
-            className='aspect-square bg-no-repeat bg-cover bg-center 
-            rounded-lg relative cursor-pointer group'
-            style={{backgroundImage: `url(${project.bgImage})`}}>
-                <div className='bg-white w-10/12 rounded-md 
-                absolute bottom-5 left-1/2 -translate-x-1/2 py-3 px-5 
-                flex items-center justify-between duration-500 group-hover:bottom-7 '>
+        {workData.map((project) => (
+            <Link
+                key={project.slug}
+                href={`/projects/${project.slug}`}
+                className='aspect-square bg-no-repeat bg-cover bg-center rounded-lg relative cursor-pointer group'
+                style={{backgroundImage: `url(${project.bgImage})`}}
+            >
+                <div className='bg-white w-10/12 rounded-md absolute bottom-5 left-1/2 -translate-x-1/2 py-3 px-5 flex items-center justify-between duration-500 group-hover:bottom-7 '>
                     <div>
                         <h2 className='font-semibold force-dark-heading-black'>{project.title}</h2>
-
                         <p className='text-sm text-gray-700'>{project.description}</p>
                     </div>
-                    <div className='border rounded-full border-black w-9
-                    aspect-square flex items-center justify-center 
-                    shadow-[2px_2px_0_#000] group-hover:bg-lime-300 transition'>
-                        <Image src={assets.send_icon} alt= 'send icon' 
-                        className='w-5'/>
+                    <div className='border rounded-full border-black w-9 aspect-square flex items-center justify-center shadow-[2px_2px_0_#000] group-hover:bg-lime-300 transition'>
+                        <Image src={assets.send_icon} alt='send icon' className='w-5'/>
                     </div>
                 </div>
-
-            </div>
+            </Link>
         ))}
         
-        <a
-            href=""
-            className="px-10 py-3 border rounded-full flex items-center gap-2 
-                        transition-colors duration-300 mx-auto my-20 w-max show-more-btn"
+        <Link
+            href="/projects"
+            className="px-10 py-3 border rounded-full flex items-center gap-2 transition-colors duration-300 mx-auto my-20 w-max show-more-btn"
             style={{
                 borderColor: 'var(--text-color)',
                 color: 'var(--text-color)'
             }}
-            >
+        >
             Show more
             <DynamicArrow className="w-4 h-4" />
-            </a>
+        </Link>
     </div>
     </div>
   )

--- a/app/projects/[slug]/page.jsx
+++ b/app/projects/[slug]/page.jsx
@@ -1,0 +1,20 @@
+import Image from 'next/image';
+import { workData } from '../../../assets/assets';
+
+export default function ProjectDetails({ params }) {
+  const project = workData.find((p) => p.slug === params.slug);
+
+  if (!project) {
+    return <div className="p-10">Project not found.</div>;
+  }
+
+  return (
+    <div className="w-full px-[12%] py-10 flex flex-col items-start gap-6">
+      <div className="w-full aspect-video relative">
+        <Image src={project.bgImage} alt={project.title} fill className="object-cover" />
+      </div>
+      <h1 className="text-4xl font-semibold" style={{color: 'var(--text-color)'}}>{project.title}</h1>
+      <p style={{color: 'var(--text-color)'}}>{project.description}</p>
+    </div>
+  );
+}

--- a/app/projects/page.jsx
+++ b/app/projects/page.jsx
@@ -1,0 +1,25 @@
+import Link from 'next/link';
+import Image from 'next/image';
+import { workData } from '../../assets/assets';
+
+export default function ProjectsPage() {
+  return (
+    <div className="w-full px-[12%] py-10 flex flex-col gap-8">
+      {workData.map((project) => (
+        <Link
+          key={project.slug}
+          href={`/projects/${project.slug}`}
+          className="border rounded-lg overflow-hidden group"
+        >
+          <div className="w-full aspect-video relative">
+            <Image src={project.bgImage} alt={project.title} fill className="object-cover" />
+          </div>
+          <div className="p-4">
+            <h2 className="text-2xl font-semibold mb-1" style={{color: 'var(--text-color)'}}>{project.title}</h2>
+            <p className="text-gray-700" style={{color: 'var(--text-color)'}}>{project.description}</p>
+          </div>
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/assets/assets.js
+++ b/assets/assets.js
@@ -97,21 +97,25 @@ export const assets = {
 
 export const workData = [
     {
+        slug: 'frontend-project',
         title: 'Frontend project',
         description: 'Web Design',
         bgImage: '/work-1.png',
     },
     {
+        slug: 'geo-based-app',
         title: 'Geo based app',
         description: 'Mobile App',
         bgImage: '/work-2.png',
     },
     {
+        slug: 'photography-site',
         title: 'Photography site',
         description: 'Web Design',
         bgImage: '/work-3.png',
     },
     {
+        slug: 'ui-ux-designing',
         title: 'UI/UX designing',
         description: 'UI/UX Design',
         bgImage: '/work-4.png',


### PR DESCRIPTION
## Summary
- add unique slugs to `workData`
- list all projects on `/projects`
- add dynamic project page `/projects/[slug]`
- link work cards and navbar to the new pages

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685001bca69c83319f20f98f2df6f553