### PR TITLE
Add Navbar to projects pages

### DIFF
--- a/app/projects/[slug]/page.jsx
+++ b/app/projects/[slug]/page.jsx
@@ -1,20 +1,46 @@
+'use client';
+import { useEffect, useState } from 'react';
 import Image from 'next/image';
 import { workData } from '../../../assets/assets';
+import Navbar from '../../components/Navbar';
 
 export default function ProjectDetails({ params }) {
+  const [isDarkMode, setIsDarkMode] = useState(true);
   const project = workData.find((p) => p.slug === params.slug);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.classList.add('theme-transition');
+
+    if (isDarkMode) {
+      root.classList.add('theme-dark');
+      localStorage.theme = 'dark';
+    } else {
+      root.classList.remove('theme-dark');
+      localStorage.theme = '';
+    }
+
+    const timeout = setTimeout(() => {
+      root.classList.remove('theme-transition');
+    }, 400);
+
+    return () => clearTimeout(timeout);
+  }, [isDarkMode]);
 
   if (!project) {
     return <div className="p-10">Project not found.</div>;
   }
 
   return (
-    <div className="w-full px-[12%] py-10 flex flex-col items-start gap-6">
-      <div className="w-full aspect-video relative">
-        <Image src={project.bgImage} alt={project.title} fill className="object-cover" />
+    <>
+      <Navbar isDarkMode={isDarkMode} setIsDarkMode={setIsDarkMode} />
+      <div className="w-full px-[12%] py-10 flex flex-col items-start gap-6">
+        <div className="w-full aspect-video relative">
+          <Image src={project.bgImage} alt={project.title} fill className="object-cover" />
+        </div>
+        <h1 className="text-4xl font-semibold" style={{color: 'var(--text-color)'}}>{project.title}</h1>
+        <p style={{color: 'var(--text-color)'}}>{project.description}</p>
       </div>
-      <h1 className="text-4xl font-semibold" style={{color: 'var(--text-color)'}}>{project.title}</h1>
-      <p style={{color: 'var(--text-color)'}}>{project.description}</p>
-    </div>
+    </>
   );
 }

--- a/app/projects/page.jsx
+++ b/app/projects/page.jsx
@@ -1,10 +1,35 @@
+'use client';
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import { workData } from '../../assets/assets';
+import Navbar from '../components/Navbar';
 
 export default function ProjectsPage() {
+  const [isDarkMode, setIsDarkMode] = useState(true);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.classList.add('theme-transition');
+    if (isDarkMode) {
+      root.classList.add('theme-dark');
+      localStorage.theme = 'dark';
+    } else {
+      root.classList.remove('theme-dark');
+      localStorage.theme = '';
+    }
+
+    const timeout = setTimeout(() => {
+      root.classList.remove('theme-transition');
+    }, 400);
+
+    return () => clearTimeout(timeout);
+  }, [isDarkMode]);
+
   return (
-    <div className="w-full px-[12%] py-10 flex flex-col gap-8">
+    <>
+      <Navbar isDarkMode={isDarkMode} setIsDarkMode={setIsDarkMode} />
+      <div className="w-full px-[12%] py-10 flex flex-col gap-8">
       {workData.map((project) => (
         <Link
           key={project.slug}
@@ -20,6 +45,7 @@ export default function ProjectsPage() {
           </div>
         </Link>
       ))}
-    </div>
+      </div>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- keep the site navigation visible on project list and details pages
- maintain theme toggling on these pages

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68500bf040108331b5210de34a09ca95