### PR TITLE
Add Navbar to projects pages

### DIFF
--- a/app/components/Navbar.jsx
+++ b/app/components/Navbar.jsx
@@ -1,6 +1,7 @@
 'use client';
 import React, { useEffect, useState, useRef } from 'react';
 import Link from 'next/link';
+import { usePathname, useRouter } from 'next/navigation';
 
 
 
@@ -9,6 +10,8 @@ const Navbar = ({ isDarkMode, setIsDarkMode }) => {
   const [isScrolled, setIsScrolled] = useState(false);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const navRef = useRef(null);
+  const pathname = usePathname();
+  const router = useRouter();
 
   useEffect(() => {
     const handleScroll = () => {
@@ -43,6 +46,16 @@ const Navbar = ({ isDarkMode, setIsDarkMode }) => {
     setIsMobileMenuOpen(false);
   };
 
+  const handleNavClick = (e, sectionId) => {
+    e.preventDefault();
+    if (pathname === '/') {
+      scrollToSection(sectionId);
+    } else {
+      router.push(`/#${sectionId}`);
+      setIsMobileMenuOpen(false);
+    }
+  };
+
   return (
     <nav 
       ref={navRef}
@@ -64,18 +77,14 @@ const Navbar = ({ isDarkMode, setIsDarkMode }) => {
         <div className="flex items-center justify-between h-16">
           {/* Logo - Fixed to left */}
           <div className="flex-shrink-0">
-            <a 
-              href="#header" 
+            <Link
+              href={pathname === '/' ? '#header' : '/#header'}
               className="text-xl font-bold"
               style={{ color: 'var(--text-color)' }}
-              onClick={(e) => {
-                e.preventDefault();
-                window.scrollTo({ top: 0, behavior: 'smooth' });
-                setIsMobileMenuOpen(false);
-              }}
+              onClick={(e) => handleNavClick(e, 'header')}
             >
               Samuel.
-            </a>
+            </Link>
           </div>
 
           {/* Desktop Navigation */}
@@ -88,18 +97,15 @@ const Navbar = ({ isDarkMode, setIsDarkMode }) => {
                 { name: 'Work', id: 'work' },
                 { name: 'Contact', id: 'contact' }
               ].map((item) => (
-                <a
+                <Link
                   key={item.id}
-                  href={`#${item.id}`}
+                  href={pathname === '/' ? `#${item.id}` : `/#${item.id}`}
                   className="px-3 py-2 rounded-md text-sm font-medium transition-colors duration-200 hover:bg-theme-hover"
                   style={{ color: 'var(--text-color)' }}
-                  onClick={(e) => {
-                    e.preventDefault();
-                    scrollToSection(item.id);
-                  }}
+                  onClick={(e) => handleNavClick(e, item.id)}
                 >
                   {item.name}
-                </a>
+                </Link>
               ))}
               <Link
                 href="/projects"
@@ -158,18 +164,15 @@ const Navbar = ({ isDarkMode, setIsDarkMode }) => {
                 { name: 'Work', id: 'work' },
                 { name: 'Contact', id: 'contact' }
               ].map((item) => (
-                <a
+                <Link
                   key={item.id}
-                  href={`#${item.id}`}
+                  href={pathname === '/' ? `#${item.id}` : `/#${item.id}`}
                   className="block px-3 py-2 rounded-md text-base font-medium transition-colors duration-200 hover:bg-theme-hover"
                   style={{ color: 'var(--text-color)' }}
-                  onClick={(e) => {
-                    e.preventDefault();
-                    scrollToSection(item.id);
-                  }}
+                  onClick={(e) => handleNavClick(e, item.id)}
                 >
                   {item.name}
-                </a>
+                </Link>
               ))}
               <Link
                 href="/projects"

--- a/app/projects/[slug]/page.jsx
+++ b/app/projects/[slug]/page.jsx
@@ -1,20 +1,46 @@
+'use client';
+import { useEffect, useState } from 'react';
 import Image from 'next/image';
 import { workData } from '../../../assets/assets';
+import Navbar from '../../components/Navbar';
 
 export default function ProjectDetails({ params }) {
+  const [isDarkMode, setIsDarkMode] = useState(true);
   const project = workData.find((p) => p.slug === params.slug);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.classList.add('theme-transition');
+
+    if (isDarkMode) {
+      root.classList.add('theme-dark');
+      localStorage.theme = 'dark';
+    } else {
+      root.classList.remove('theme-dark');
+      localStorage.theme = '';
+    }
+
+    const timeout = setTimeout(() => {
+      root.classList.remove('theme-transition');
+    }, 400);
+
+    return () => clearTimeout(timeout);
+  }, [isDarkMode]);
 
   if (!project) {
     return <div className="p-10">Project not found.</div>;
   }
 
   return (
-    <div className="w-full px-[12%] py-10 flex flex-col items-start gap-6">
-      <div className="w-full aspect-video relative">
-        <Image src={project.bgImage} alt={project.title} fill className="object-cover" />
+    <>
+      <Navbar isDarkMode={isDarkMode} setIsDarkMode={setIsDarkMode} />
+      <div className="w-full px-[12%] pt-24 pb-10 flex flex-col items-start gap-6">
+        <div className="w-full aspect-video relative">
+          <Image src={project.bgImage} alt={project.title} fill className="object-cover" />
+        </div>
+        <h1 className="text-4xl font-semibold" style={{color: 'var(--text-color)'}}>{project.title}</h1>
+        <p style={{color: 'var(--text-color)'}}>{project.description}</p>
       </div>
-      <h1 className="text-4xl font-semibold" style={{color: 'var(--text-color)'}}>{project.title}</h1>
-      <p style={{color: 'var(--text-color)'}}>{project.description}</p>
-    </div>
+    </>
   );
 }

--- a/app/projects/page.jsx
+++ b/app/projects/page.jsx
@@ -1,10 +1,35 @@
+'use client';
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import { workData } from '../../assets/assets';
+import Navbar from '../components/Navbar';
 
 export default function ProjectsPage() {
+  const [isDarkMode, setIsDarkMode] = useState(true);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.classList.add('theme-transition');
+    if (isDarkMode) {
+      root.classList.add('theme-dark');
+      localStorage.theme = 'dark';
+    } else {
+      root.classList.remove('theme-dark');
+      localStorage.theme = '';
+    }
+
+    const timeout = setTimeout(() => {
+      root.classList.remove('theme-transition');
+    }, 400);
+
+    return () => clearTimeout(timeout);
+  }, [isDarkMode]);
+
   return (
-    <div className="w-full px-[12%] py-10 flex flex-col gap-8">
+    <>
+      <Navbar isDarkMode={isDarkMode} setIsDarkMode={setIsDarkMode} />
+      <div className="w-full px-[12%] pt-24 pb-10 flex flex-col gap-8">
       {workData.map((project) => (
         <Link
           key={project.slug}
@@ -20,6 +45,7 @@ export default function ProjectsPage() {
           </div>
         </Link>
       ))}
-    </div>
+      </div>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- keep the site navigation visible on project list and details pages
- maintain theme toggling on these pages
- fix navigation links so they work from any page
- offset content so the Navbar doesn't cover projects

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68500bf040108331b5210de34a09ca95