### PR TITLE
Fix container markup on project pages

### DIFF
--- a/app/projects/[slug]/page.jsx
+++ b/app/projects/[slug]/page.jsx
@@ -35,6 +35,7 @@ export default function ProjectDetails({ params }) {
     <>
       <Navbar isDarkMode={isDarkMode} setIsDarkMode={setIsDarkMode} />
 
+      <div className="w-full px-[12%] pt-24 pb-10 flex flex-col items-start gap-6">
         <div className="w-full aspect-video relative">
           <Image src={project.bgImage} alt={project.title} fill className="object-cover" />
         </div>

--- a/app/projects/page.jsx
+++ b/app/projects/page.jsx
@@ -30,21 +30,22 @@ export default function ProjectsPage() {
     <>
       <Navbar isDarkMode={isDarkMode} setIsDarkMode={setIsDarkMode} />
 
-      {workData.map((project) => (
-        <Link
-          key={project.slug}
-          href={`/projects/${project.slug}`}
-          className="border rounded-lg overflow-hidden group"
-        >
-          <div className="w-full aspect-video relative">
-            <Image src={project.bgImage} alt={project.title} fill className="object-cover" />
-          </div>
-          <div className="p-4">
-            <h2 className="text-2xl font-semibold mb-1" style={{color: 'var(--text-color)'}}>{project.title}</h2>
-            <p className="text-gray-700" style={{color: 'var(--text-color)'}}>{project.description}</p>
-          </div>
-        </Link>
-      ))}
+      <div className="w-full px-[12%] pt-24 pb-10 flex flex-col gap-8">
+        {workData.map((project) => (
+          <Link
+            key={project.slug}
+            href={`/projects/${project.slug}`}
+            className="border rounded-lg overflow-hidden group"
+          >
+            <div className="w-full aspect-video relative">
+              <Image src={project.bgImage} alt={project.title} fill className="object-cover" />
+            </div>
+            <div className="p-4">
+              <h2 className="text-2xl font-semibold mb-1" style={{color: 'var(--text-color)'}}>{project.title}</h2>
+              <p className="text-gray-700" style={{color: 'var(--text-color)'}}>{project.description}</p>
+            </div>
+          </Link>
+        ))}
       </div>
     </>
   );


### PR DESCRIPTION
## Summary
- wrap project lists and details in container divs so markup is valid

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68511d3b310483318836fb084db23c46