### PR TITLE
Fix slug extraction in project pages

### DIFF
--- a/app/projects/[slug]/page.jsx
+++ b/app/projects/[slug]/page.jsx
@@ -1,12 +1,13 @@
 'use client';
-import { useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import Image from 'next/image';
 import { workData } from '../../../assets/assets';
 import Navbar from '../../components/Navbar';
 
 export default function ProjectDetails({ params }) {
+  const { slug } = React.use(params);
   const [isDarkMode, setIsDarkMode] = useState(true);
-  const project = workData.find((p) => p.slug === params.slug);
+  const project = workData.find((p) => p.slug === slug);
 
   useEffect(() => {
     const root = document.documentElement;


### PR DESCRIPTION
## Summary
- import `React` in the project details page
- unwrap route params using `React.use`
- use the resolved `slug` when looking up project info

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851210f44588331990d7efcc7c44422