### PR TITLE
Invert tools icons in dark mode

### DIFF
--- a/app/components/About.jsx
+++ b/app/components/About.jsx
@@ -76,7 +76,7 @@ const About = () => {
                 w-12 sm:w-14 aspect-square border border-gray-400 
                 rounded-lg cursor-pointer hover:-translate-y-1 duration-500'
               >
-                <Image src={tool} alt='Tool' className='w-5 sm:w-7' />
+                <Image src={tool} alt='Tool' className='w-5 sm:w-7 invert-on-dark' />
               </li>
             ))}
           </ul>

--- a/app/globals.css
+++ b/app/globals.css
@@ -240,3 +240,8 @@ body {
   background-image: none;
 }
 
+/* Utility class to invert icons when dark mode is active */
+.theme-dark .invert-on-dark {
+  filter: brightness(0) invert(1);
+}
+


### PR DESCRIPTION
## Summary
- add `invert-on-dark` utility class for dark mode icon inversion
- apply `invert-on-dark` to the tools icons

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68513d40d2f883318d2efa01397c6c11